### PR TITLE
v1.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ bin
 obj
 *.DotSettings.user
 .vs
+
+spookbox

--- a/Entries/TrackEntry.cs
+++ b/Entries/TrackEntry.cs
@@ -13,6 +13,10 @@ namespace Spookbox.Entries
             get => _trackIndex;
             set
             {
+                if (Mixtape.Tracks.Count == 0)
+                {
+                    return;
+                }
                 _trackIndex = Math.Clamp(value, 0, Mixtape.Tracks.Count-1);
                 TrackName = FormatTrackName();
             } 

--- a/SpookboxPlugin.config.cs
+++ b/SpookboxPlugin.config.cs
@@ -39,13 +39,9 @@ public partial class SpookboxPlugin
 
     private static void _priceSetting_Changed(int obj)
     {
-        if (SynchronisedMetadata<bool>.InLobby == false)
+        if (Shop.UpdateItemPrice(_spookboxItem, obj) == false)
         {
-            _spookboxItem.price = obj;
-        }
-        else
-        {
-            Debug.LogWarning($"Attempted to apply {nameof(BoomboxPriceSetting)} value to item while in a lobby. Item price can only be changed outside of the lobby; please restart the lobby to change this setting.");
+            Debug.LogWarning($"Attempted to apply {nameof(BoomboxPriceSetting)} value to item while not the host of the current lobby.");
         }
     }
 

--- a/publish/thunderstore/CHANGELOG.md
+++ b/publish/thunderstore/CHANGELOG.md
@@ -3,5 +3,12 @@
 All notable changes will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.2
+- Fixed issue during config if no tracks were loaded
+- Removed BoomboxPriceSetting no lobby restriction. Price can now be changed even in a lobby, but only by the host.
+
+## 1.0.1
+- Added missing resource file
+
 ## 1.0.0
 - Initial Release

--- a/publish/thunderstore/CHANGELOG.md
+++ b/publish/thunderstore/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## 1.0.2
 - Fixed issue during config if no tracks were loaded
 - Removed BoomboxPriceSetting no lobby restriction. Price can now be changed even in a lobby, but only by the host.
+- Adjusted Spookbox text emission to be slightly green
 
 ## 1.0.1
 - Added missing resource file

--- a/publish/thunderstore/README.md
+++ b/publish/thunderstore/README.md
@@ -59,7 +59,7 @@ Check this if you don't want the boombox to ever run out of battery. Only the ho
 
 ### [HOST] Price
 
-Sets the boombox's price. By default it is 100$. Only the host can set this. Once a lobby has been created, changing it will have no effect until a new lobby is started, so set this early, before starting a game.
+Sets the boombox's price. By default it is 100$. Only the host can set this, but they may freely change it anytime during the run (which will affect everyone).
 
 
 ## Credits

--- a/publish/thunderstore/manifest.json
+++ b/publish/thunderstore/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Spookbox",
-    "version_number": "1.0.0",
+    "version_number": "1.0.2",
     "website_url": "https://github.com/Xerren09/ContentWarningSpookbox",
     "description": "Adds a silly boombox (The Spöökbox™) to the store so you can dance to any tune you want while going viral :]",
     "dependencies": [

--- a/publish/thunderstore/manifest.json
+++ b/publish/thunderstore/manifest.json
@@ -5,6 +5,6 @@
     "description": "Adds a silly boombox (The Spöökbox™) to the store so you can dance to any tune you want while going viral :]",
     "dependencies": [
         "BepInEx-BepInExPack-5.4.2100",
-        "Xerren-ShopAPI-1.0.2"
+        "Xerren-ShopAPI-1.1.0"
     ]
 }


### PR DESCRIPTION
Fixed issue during config if no tracks were loaded that caused the item to disappear.

Removed BoomboxPriceSetting no lobby restriction. Price can now be changed even in a lobby, but only by the host.

Adjusted Spookbox text emission to be slightly green.