### PR TITLE
Fix steam late install issue

### DIFF
--- a/Behaviour/SpookboxBehaviour.cs
+++ b/Behaviour/SpookboxBehaviour.cs
@@ -21,6 +21,7 @@ namespace Spookbox.Behaviour
         private BoomboxVolumeUpBindSetting _volumeUpBindSetting;
         private BoomboxVolumeDownBindSetting _volumeDownBindSetting;
 
+        private static readonly int _defaultAlertDistance = 35;
         private float _alertCountdown = 0f;
         private float _alertInterval = 0.15f;
         private int _instanceTrackIndex = -1;
@@ -106,7 +107,7 @@ namespace Spookbox.Behaviour
                 _alertCountdown -= Time.deltaTime;
                 if (_alertCountdown < 0f)
                 {
-                    SFX_Player.instance.PlayNoise(base.transform.position, 35f);
+                    SFX_Player.instance.PlayNoise(base.transform.position, _defaultAlertDistance);
                     _alertCountdown = _alertInterval;
                 }
             }

--- a/Behaviour/StashedSpookboxBehaviour.cs
+++ b/Behaviour/StashedSpookboxBehaviour.cs
@@ -11,6 +11,10 @@ namespace Spookbox.Behaviour
         private AudioSource _speaker;
         private BoomboxLocalVolumeSetting _localVolumeSetting;
 
+        private static readonly int _defaultAlertDistance = 35;
+        private float _alertCountdown = 0f;
+        private float _alertInterval = 0.15f;
+
         void Awake()
         {
             _speaker = GetComponent<AudioSource>();
@@ -49,6 +53,15 @@ namespace Spookbox.Behaviour
                     Destroy(gameObject);
                 }
                 _batteryEntry.m_charge -= Time.deltaTime;
+            }
+            if (SpookboxPlugin.AlertMonsters.Value == true)
+            {
+                _alertCountdown -= Time.deltaTime;
+                if (_alertCountdown < 0f)
+                {
+                    SFX_Player.instance.PlayNoise(base.transform.position, _defaultAlertDistance);
+                    _alertCountdown = _alertInterval;
+                }
             }
         }
     }

--- a/Mixtape.cs
+++ b/Mixtape.cs
@@ -61,7 +61,6 @@ namespace Spookbox
                 Tracks.Add(track);
                 Debug.Log($"Added track to mixtape: {track.name}");
             }
-
         }
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Check this if you don't want the boombox to ever run out of battery. Only the ho
 
 ### [HOST] Price
 
-Sets the boombox's price. By default it is 100$. Only the host can set this. Once a lobby has been created, changing it will have no effect until a new lobby is started, so set this early, before starting a game.
+Sets the boombox's price. By default it is 100$. Only the host can set this, but they may freely change it anytime during the run (which will affect everyone).
 
 
 ## Credits

--- a/Settings.cs
+++ b/Settings.cs
@@ -2,6 +2,7 @@
 using Unity.Mathematics;
 using Zorro.Settings;
 using Spookbox.Entries;
+using ContentWarningShop;
 
 namespace Spookbox.Settings
 {
@@ -85,10 +86,9 @@ namespace Spookbox.Settings
     [ContentWarningSetting]
     public class BoomboxAlertSetting : BoolSetting, IExposedSetting
     {
-        public event Action<bool> Changed;
         public override void ApplyValue()
         {
-            Changed?.Invoke(Value);
+            SpookboxPlugin.AlertMonsters.SetValue(Value);
         }
         public SettingCategory GetSettingCategory() => SettingCategory.Mods;
         public string GetDisplayName() => $"[{SpookboxPlugin.MOD_NAME}] Let BigSlap hear the tunes (Host)";
@@ -108,10 +108,9 @@ namespace Spookbox.Settings
     [ContentWarningSetting]
     public class BoomboxInfiniteBatterySetting : BoolSetting, IExposedSetting
     {
-        public event Action<bool> Changed;
         public override void ApplyValue()
         {
-            Changed?.Invoke(Value);
+            SpookboxPlugin.InfiniteBattery.SetValue(Value);
         }
         public SettingCategory GetSettingCategory() => SettingCategory.Mods;
         public string GetDisplayName() => $"[{SpookboxPlugin.MOD_NAME}] Infinite battery (Host)";
@@ -128,10 +127,12 @@ namespace Spookbox.Settings
     [ContentWarningSetting]
     public class BoomboxPriceSetting : IntSetting, IExposedSetting
     {
-        public event Action<int> Changed;
         public override void ApplyValue()
         {
-            Changed?.Invoke(Value);
+            if (Shop.UpdateItemPrice(SpookboxPlugin._spookboxItem, Value) == false)
+            {
+                Debug.LogWarning($"Attempted to apply {nameof(BoomboxPriceSetting)} value to item while not the host of the current lobby.");
+            }
         }
         public SettingCategory GetSettingCategory() => SettingCategory.Mods;
         public string GetDisplayName() => $"[{SpookboxPlugin.MOD_NAME}] Price (Host)";

--- a/Spookbox.csproj
+++ b/Spookbox.csproj
@@ -14,6 +14,7 @@
 		<AssemblyName Condition="'$(Configuration)'!='Modman (Release)'">$(AssemblyName)</AssemblyName>
 		<AssemblyName Condition="'$(Configuration)'=='Modman (Release)'">$(AssemblyName).bepinex</AssemblyName>
 		-->
+		<AssemblyVersion>1.0.3.0</AssemblyVersion>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Spookbox.csproj
+++ b/Spookbox.csproj
@@ -15,6 +15,7 @@
 		<AssemblyName Condition="'$(Configuration)'=='Modman (Release)'">$(AssemblyName).bepinex</AssemblyName>
 		-->
 		<AssemblyVersion>1.0.3.0</AssemblyVersion>
+        <FileVersion>1.0.3.0</FileVersion>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/SpookboxPlugin.config.cs
+++ b/SpookboxPlugin.config.cs
@@ -1,63 +1,60 @@
 ﻿using UnityEngine;
 using Spookbox.Settings;
 using ContentWarningShop;
+using Zorro.Settings;
+using Steamworks;
 
 namespace Spookbox;
 
 public partial class SpookboxPlugin
 {
     private static bool _initialised = false;
+    private static Callback<LobbyCreated_t> cb_onLobbyCreated = Callback<LobbyCreated_t>.Create(Steam_LobbyCreated);
+
     private const string ALERT_META_GUID = "bigslapTunes";
     internal static readonly SynchronisedMetadata<bool> AlertMonsters = new($"{MOD_GUID}_{ALERT_META_GUID}", true);
-    private static BoomboxAlertSetting _alertSetting;
 
     private const string INF_BATTERY_META_GUID = "infiniteBattery";
     internal static readonly SynchronisedMetadata<bool> InfiniteBattery = new($"{MOD_GUID}_{INF_BATTERY_META_GUID}", false);
-    private static BoomboxInfiniteBatterySetting _infiniteBatterySetting;
-
-    private static BoomboxPriceSetting _priceSetting;
 
     internal static void InitialiseSettings()
     {
         if (_initialised) return;
-        _alertSetting = GameHandler.Instance.SettingsHandler.GetSetting<BoomboxAlertSetting>();
-        _alertSetting.Changed += _alertSetting_Changed;
-        AlertMonsters.SetValue(_alertSetting.Value);
 
-        _infiniteBatterySetting = GameHandler.Instance.SettingsHandler.GetSetting<BoomboxInfiniteBatterySetting>();
-        _infiniteBatterySetting.Changed += _infiniteBatterySetting_Changed;
-        InfiniteBattery.SetValue(_infiniteBatterySetting.Value);
-
-        _priceSetting = GameHandler.Instance.SettingsHandler.GetSetting<BoomboxPriceSetting>();
-        _priceSetting.Changed += _priceSetting_Changed;
-        _spookboxItem.price = _priceSetting.Value;
+        InitialiseGameSetting<BoomboxAlertSetting>();
+        InitialiseGameSetting<BoomboxInfiniteBatterySetting>();
+        InitialiseGameSetting<BoomboxPriceSetting>();
 
         _initialised = true;
 
         Debug.Log($"{MOD_GUID} settings initialised.");
     }
 
-    private static void _priceSetting_Changed(int obj)
+    private static void Steam_LobbyCreated(LobbyCreated_t e)
     {
-        if (Shop.UpdateItemPrice(_spookboxItem, obj) == false)
+        if (e.m_eResult != EResult.k_EResultOK)
         {
-            Debug.LogWarning($"Attempted to apply {nameof(BoomboxPriceSetting)} value to item while not the host of the current lobby.");
+            return;
+        }
+        ApplyGameSetting<BoomboxAlertSetting>();
+        ApplyGameSetting<BoomboxInfiniteBatterySetting>();
+        ApplyGameSetting<BoomboxPriceSetting>();
+    }
+
+    private static void InitialiseGameSetting<T>() where T : Setting, new()
+    {
+        if (GameHandler.Instance.SettingsHandler.GetSetting<T>() == null)
+        {
+            GameHandler.Instance.SettingsHandler.AddSetting(new T());
         }
     }
 
-    private static void _alertSetting_Changed(bool obj)
+    private static void ApplyGameSetting<T>() where T : Setting, new()
     {
-        if (AlertMonsters.CanSet())
+        var setting = GameHandler.Instance.SettingsHandler.GetSetting<T>();
+        if (setting != null)
         {
-            AlertMonsters.SetValue(obj);
-        }
-    }
-
-    private static void _infiniteBatterySetting_Changed(bool obj)
-    {
-        if (InfiniteBattery.CanSet())
-        {
-            InfiniteBattery.SetValue(obj);
+            setting.ApplyValue();
         }
     }
 }

--- a/SpookboxPlugin.cs
+++ b/SpookboxPlugin.cs
@@ -25,7 +25,7 @@ using HarmonyLib;
 namespace Spookbox
 {
     // This partial class file is used purely to separate the mess that is the multi target setup.
-    // Define changes mod setup changes between the vanilla mod loader and bepinx
+    // Define mod setup changes between the vanilla mod loader and bepinx
     [ContentWarningPlugin(MOD_GUID, MOD_VER, false)]
 #if MODMAN
     [BepInPlugin(MOD_GUID, MOD_NAME, MOD_VER)]
@@ -55,12 +55,20 @@ namespace Spookbox
         void Awake()
 #endif
         {
+            Initialise();
 #if STEAM
             Debug.Log($"{MOD_GUID} initialising via the vanilla mod loader.");
+            GameHandler.Instance.StartCoroutine(Deferred_LoadSettings());
 #elif MODMAN
             Debug.Log($"{MOD_GUID} initialising via BepInEx mod loader.");
+            // Mod will initialise on GameHandler.Initialize
             harmony.PatchAll();
 #endif
+            Debug.Log($"{MOD_GUID} initialised.");
+        }
+
+        private static void Initialise()
+        {
             _bundle = LoadAssetBundle();
             _spookboxItem = _bundle.LoadAsset<Item>("Spookbox");
             _spookboxItem.itemObject.AddComponent<SpookboxBehaviour>();
@@ -71,12 +79,6 @@ namespace Spookbox
             _spookboxItem.SetDefaultTooltips($"{ShopLocalisation.UseGlyph} Play;{ShopLocalisation.Use2Glyph} Next Track");
 
             Mixtape.LoadTracks();
-
-#if STEAM
-            GameHandler.Instance.StartCoroutine(Deferred_LoadSettings());
-#endif
-
-            Debug.Log($"{MOD_GUID} initialised.");
         }
 
 #if STEAM

--- a/publish/thunderstore/CHANGELOG.md
+++ b/publish/thunderstore/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 1.0.3
 - Added missing monster alerts when boombox is stashed
+- Host settings are now correctly applied when you leave a lobby and then host your own
 - Changed mod startup to manually register settings
   - This (hopefully) fixes the surprisingly common scenario where if the mod is installed *after* the game is started, the game doesn't auto register its settings.
 

--- a/publish/thunderstore/CHANGELOG.md
+++ b/publish/thunderstore/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.3
+- Added missing monster alerts when boombox is stashed
+- Changed mod startup to manually register settings
+  - This (hopefully) fixes the surprisingly common scenario where if the mod is installed *after* the game is started, the game doesn't auto register its settings.
+
 ## 1.0.2
 - Fixed issue during config if no tracks were loaded
 - Removed BoomboxPriceSetting no lobby restriction. Price can now be changed even in a lobby, but only by the host.

--- a/publish/thunderstore/manifest.json
+++ b/publish/thunderstore/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Spookbox",
-    "version_number": "1.0.2",
+    "version_number": "1.0.3",
     "website_url": "https://github.com/Xerren09/ContentWarningSpookbox",
     "description": "Adds a silly boombox (The Spöökbox™) to the store so you can dance to any tune you want while going viral :]",
     "dependencies": [


### PR DESCRIPTION
- Added missing monster alerts when boombox is stashed
- Host settings are now correctly applied when you leave a lobby and then host your own
- Changed mod startup to manually register settings
  - This (hopefully) fixes the surprisingly common scenario where if the mod is installed *after* the game is started, the game doesn't auto register its settings.